### PR TITLE
Handle sigint: fixup

### DIFF
--- a/ptd_client_server/lib.py
+++ b/ptd_client_server/lib.py
@@ -164,9 +164,15 @@ class SignalHandler:
             self.force_stopped = True
             exit(1)
 
+    def check(self) -> None:
+        if self.stopped:
+            raise KeyboardInterrupt
+
     def __enter__(self) -> "SignalHandler":
         """Enable KeyboardInterrupt temporarely."""
         self._enable_exception = True
+        if self.stopped:
+            raise KeyboardInterrupt
         return self
 
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:

--- a/ptd_client_server/server.py
+++ b/ptd_client_server/server.py
@@ -190,11 +190,8 @@ class Server:
 
         try:
             while True:
-                try:
-                    with lib.sig:
-                        cmd = p.recv()
-                except KeyboardInterrupt:
-                    break
+                with lib.sig:
+                    cmd = p.recv()
 
                 if cmd is None:
                     logging.info("Connection closed")
@@ -321,5 +318,7 @@ lib.ntp_sync(config.ntp_server)
 server = Server(config)
 try:
     lib.run_server(args.ipAddress, args.serverPort, server.handle_connection)
+except KeyboardInterrupt:
+    pass
 finally:
     server.close()


### PR DESCRIPTION
Follow-up for #23, #11.

Covers an additional case: the first `Ctrl+C` after `SR,V,300` command were ignored.