### PR TITLE
client: Revisit log directories configuration

### DIFF
--- a/ptd_client_server/lib/common.py
+++ b/ptd_client_server/lib/common.py
@@ -319,6 +319,22 @@ def ntp_sync(server: Optional[str]) -> None:
             raise
 
 
+def mkdir_if_ne(path: str) -> None:
+    """mkdir if not exists"""
+    # TODO: check permissions?
+    logging.info(f"Creating output directory {path!r}")
+
+    if not os.path.exists(path):
+        try:
+            os.mkdir(path)
+        except FileNotFoundError:
+            logging.fatal(
+                f"Could not create directory {path!r}. "
+                "Make sure all intermediate directories exist."
+            )
+            exit(1)
+
+
 def human_bytes(num: int) -> str:
     num = float(num)
     unit_labels = ["B", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"]

--- a/ptd_client_server/lib/server.py
+++ b/ptd_client_server/lib/server.py
@@ -575,14 +575,7 @@ def main() -> None:
 
     config = ServerConfig(args.configurationFile)
 
-    if not os.path.exists(config.out_dir):
-        try:
-            os.mkdir(config.out_dir)
-        except FileNotFoundError:
-            exit_with_error_msg(
-                f"Could not create directory {config.out_dir!r}. "
-                "Make sure all intermediate directories exist."
-            )
+    common.mkdir_if_ne(config.out_dir)
 
     common.ntp_sync(config.ntp_server)
 


### PR DESCRIPTION
* Add `--loadgen-logs` argument.
* Get rid of `"$out"` environment variable.
* Prefix output sub-directories with a label and a timestamp in the. So now the client and the server have a similar output directory layout.
* Update readme accordingly.
* Also, additional misc fixes in the readme.

Closes #54.