### PR TITLE
Log source hashes

### DIFF
--- a/ptd_client_server/.gitattributes
+++ b/ptd_client_server/.gitattributes
@@ -1,0 +1,2 @@
+# Disable git's CRLF conversion on Windows which may wreck checksum computation
+*.py -text

--- a/ptd_client_server/client.py
+++ b/ptd_client_server/client.py
@@ -14,7 +14,9 @@
 # limitations under the License.
 # =============================================================================
 
-from lib import client
+from lib import client, source_hashes
+
+source_hashes.init()
 
 if __name__ == "__main__":
     client.main()

--- a/ptd_client_server/lib/client.py
+++ b/ptd_client_server/lib/client.py
@@ -182,6 +182,8 @@ def main() -> None:
         )
         exit(1)
 
+    common.log_sources()
+
     for mode in ["ranging", "testing"]:
         logging.info(f"Running workload in {mode} mode")
         out = os.path.join(args.output, f"{session}_{mode}")

--- a/ptd_client_server/lib/common.py
+++ b/ptd_client_server/lib/common.py
@@ -14,6 +14,7 @@
 # =============================================================================
 
 from typing import Any, Callable, Optional
+import json
 import logging
 import os
 import select
@@ -24,6 +25,8 @@ import string
 import subprocess
 import sys
 import time
+
+from . import source_hashes
 
 
 DEFAULT_PORT = 4950
@@ -380,3 +383,7 @@ def human_bytes(num: int) -> str:
             num /= 1000
 
     return f"{num:.1f} {unit}"
+
+
+def log_sources() -> None:
+    logging.info("Sources: " + json.dumps(source_hashes.get()))

--- a/ptd_client_server/lib/server.py
+++ b/ptd_client_server/lib/server.py
@@ -644,6 +644,8 @@ def main() -> None:
 
     common.ntp_sync(config.ntp_server)
 
+    common.log_sources()
+
     server = Server(config)
     try:
         common.run_server(

--- a/ptd_client_server/lib/source_hashes.py
+++ b/ptd_client_server/lib/source_hashes.py
@@ -1,0 +1,139 @@
+# Copyright 2018 The MLPerf Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+from collections import OrderedDict
+from typing import Any, Dict, List
+import hashlib
+import inspect
+import logging
+import os
+import pathlib
+import sys
+
+_source_hashes: object = None
+
+_module_name = "lib"
+
+
+def get() -> object:
+    """Should be called after init()."""
+
+    assert (
+        _source_hashes is not None
+    ), "_source_hashes is None. init() should be called first"
+    return _source_hashes
+
+
+def init() -> None:
+    """Populate the global variable containing source code checksums.
+    Should be called right after importing all modules.
+    Note that source files could change mid-execution, so this should be called
+    as early as possible.
+    """
+
+    global _source_hashes
+
+    assert _source_hashes is None, "init() already called"
+
+    base_dir = pathlib.Path(sys.modules["__main__"].__file__).parent
+
+    result: Any = {
+        "sources": {},
+        "modules": {},
+    }
+
+    for path, dirs, files in os.walk(base_dir, topdown=True):
+        exclude = {
+            "__pycache__",
+            ".mypy_cache",
+            ".pytest_cache",
+        }
+        dirs[:] = [d for d in dirs if d not in exclude]
+
+        relpath = os.path.relpath(path, base_dir)
+        if relpath == ".":
+            relpath = ""
+        for file in filter(lambda f: f.endswith(".py"), files):
+            fname = os.path.join(relpath, file)
+            with open(os.path.join(path, file), "rb") as f:
+                b_source = f.read()
+                if b"\r" in b_source:
+                    logging.fatal(
+                        f"{file} contains '\\r'."
+                        "Make sure that source files are not converted to CRLF format."
+                    )
+                    exit(1)
+                result["sources"][_normalize(fname)] = hashlib.sha1(
+                    b_source
+                ).hexdigest()
+
+    for name, module in sys.modules.items():
+        if not (
+            name == "__main__"
+            or name == _module_name
+            or name.startswith(_module_name + ".")
+        ):
+            continue
+
+        try:
+            source = inspect.getsource(sys.modules[name])
+            fname_ = inspect.getsourcefile(sys.modules[name])
+            assert fname_ is not None
+            fname = fname_
+        except (TypeError, OSError):
+            # TypeError: <module 'sys' (built-in)> is a built-in module
+            # OSError: source code not available
+            continue
+
+        hash = hashlib.sha1(source.encode("utf8")).hexdigest()
+        relpath = _normalize(os.path.relpath(fname, base_dir))
+
+        if relpath not in result["sources"]:
+            logging.fatal(
+                f"Module {name} at {relpath!r} is not within the source code directory"
+            )
+            exit(1)
+        if result["sources"][relpath] != hash:
+            logging.fatal(
+                f"Module {name} at {relpath!r} hash mismach {result['sources'][relpath]} != {hash}"
+            )
+            exit(1)
+
+        result["modules"][name] = relpath
+
+    result["sources"] = _sort_dict(result["sources"])
+    result["modules"] = _sort_dict(result["modules"])
+
+    _source_hashes = result
+
+
+def _normalize(path: str) -> str:
+    allparts: List[str] = []
+    while 1:
+        parts = os.path.split(path)
+        if parts[0] == path:  # sentinel for absolute paths
+            allparts.insert(0, parts[0])
+            break
+        elif parts[1] == path:  # sentinel for relative paths
+            allparts.insert(0, parts[1])
+            break
+        else:
+            path = parts[0]
+            allparts.insert(0, parts[1])
+    return "/".join(allparts)
+
+
+def _sort_dict(x: Dict[str, Any]) -> "OrderedDict[str, Any]":
+    return OrderedDict(sorted(x.items()))

--- a/ptd_client_server/server.py
+++ b/ptd_client_server/server.py
@@ -14,7 +14,9 @@
 # limitations under the License.
 # =============================================================================
 
-from lib import server
+from lib import server, source_hashes
+
+source_hashes.init()
 
 if __name__ == "__main__":
     server.main()

--- a/ptd_client_server/tests/unit/test_source_hashes.py
+++ b/ptd_client_server/tests/unit/test_source_hashes.py
@@ -1,0 +1,68 @@
+# Copyright 2018 The MLPerf Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+from pathlib import Path
+import json
+import shutil
+import subprocess
+import sys
+
+
+def test_foo(tmp_path: Path) -> None:
+    shutil.copytree(Path(__file__).parent.parent.parent / "lib", tmp_path / "lib")
+    with open(tmp_path / "main.py", "wb") as f:
+        f.write(
+            b"from lib import source_hashes\n"
+            b"import json\n"
+            b"source_hashes.init()\n"
+            b"print(json.dumps(source_hashes.get()))\n"
+        )
+
+    results = []
+
+    results.append(
+        subprocess.check_output(
+            [sys.executable, str(tmp_path / "main.py")],
+            cwd="C:\\" if sys.platform == "win32" else "/",
+        )
+    )
+    results.append(
+        subprocess.check_output(
+            [sys.executable, "main.py"],
+            cwd=tmp_path,
+        )
+    )
+    results.append(
+        subprocess.check_output(
+            [sys.executable, "./main.py"],
+            cwd=tmp_path,
+        )
+    )
+    if sys.platform == "win32":
+        results.append(
+            subprocess.check_output(
+                [sys.executable, ".\\main.py"],
+                cwd=tmp_path,
+            )
+        )
+
+    for result in results[1:]:
+        assert results[0] == result
+
+    parsed_result = json.loads(results[0])
+    assert "sources" in parsed_result
+    assert "modules" in parsed_result
+    assert "main.py" in parsed_result["sources"]
+    assert "lib/source_hashes.py" in parsed_result["sources"]


### PR DESCRIPTION
Closes #98

Situations considered:
* Automatic conversion LF -> CRLF on Windows.
* Source files updated mid execution.
* `os.path.sep` differences on Windows and Linux.
* Other possible weirdness.

Example output:
`
ptd-server 2021-01-28 04:24:42,481 [INFO] Sources: {"sources": {"client.py": "d1e75cb4b26101220ebd242e584cf3ca5d8f1996", "lib/__init__.py": "da39a3ee5e6b4b0d3255bfef95601890afd80709", "lib/client.py": "b9e5fdd74888c16463e26a92c67015784b69c32c", "lib/common.py": "cb4109747e4a1c8fcdc8bbd2034da4830e089797", "lib/server.py": "326aa261a26dc489f962f0d2896de346cfc885ec", "lib/source_hashes.py": "48994aefa6c42e29d4f7372e7b2877428d487228", "server.py": "99e1310e3f76292aef1b8792ce6b8c82f1d44d8b", "tests/unit/test_server.py": "10506425ab82ae87cb88706b29a7335554fab798", "tests/unit/test_source_hashes.py": "cb41a7261eaf7d94ba5c0aae9c523174f6204be3"}, "modules": {"__main__": "server.py", "lib.common": "lib/common.py", "lib.server": "lib/server.py", "lib.source_hashes": "lib/source_hashes.py"}}
`